### PR TITLE
gui: set tw_file to the currently flashed file name without path

### DIFF
--- a/gui/action.cpp
+++ b/gui/action.cpp
@@ -995,15 +995,19 @@ int GUIAction::flash(std::string arg)
 	// We're going to jump to this page first, like a loading page
 	gui_changePage(arg);
 	for (i=0; i<zip_queue_index; i++) {
+		string zip_path = zip_queue[i];
+		size_t slashpos = zip_path.find_last_of('/');
+		string zip_filename = (slashpos == string::npos) ? zip_path : zip_path.substr(slashpos + 1);
 		operation_start("Flashing");
-		DataManager::SetValue("tw_filename", zip_queue[i]);
+		DataManager::SetValue("tw_filename", zip_path);
+		DataManager::SetValue("tw_file", zip_filename);
 		DataManager::SetValue(TW_ZIP_INDEX, (i + 1));
 
 		TWFunc::SetPerformanceMode(true);
-		ret_val = flash_zip(zip_queue[i], &wipe_cache);
+		ret_val = flash_zip(zip_path, &wipe_cache);
 		TWFunc::SetPerformanceMode(false);
 		if (ret_val != 0) {
-			gui_print("Error flashing zip '%s'\n", zip_queue[i].c_str());
+			gui_print("Error flashing zip '%s'\n", zip_path.c_str());
 			ret_val = 1;
 			break;
 		}


### PR DESCRIPTION
To allow themes to show more of the file name on narrow displays.

Change-Id: I4962eed5e4a01f73a3cde126f2ba56428209fccc